### PR TITLE
Smooth line animation fixes #29

### DIFF
--- a/google-map-storyboard.html
+++ b/google-map-storyboard.html
@@ -360,10 +360,21 @@ Fired when the storybord's google map is ready to be rendered.
     },
 
     makePolyline: function(opacity) {
+      var dash = {
+        path: 'M 0,0 0,1',  // This is the svg for a dash.
+        strokeOpacity: opacity,
+        scale: 2
+      };
+      // The dash symbol (see icons) is repeated every 2px to form a solid line.
       var lineOptions = {
         map: this.map,
         geodesic: true,
-        strokeOpacity: opacity
+        strokeOpacity: 0,  // The line underneath the dashes is not visible.
+        icons: [{
+          icon: dash,
+          offset: '0px',
+          repeat: '2px'
+        }]
       };
       return new google.maps.Polyline(lineOptions);
     }


### PR DESCRIPTION
Making the polyline out of numerous small dashes.

This stops the polyline from wobbling as it is animated.

Currently no way of formatting the polyline as a developer.
