### PR TITLE
Remove flash of scene content on initialisation.

### DIFF
--- a/google-map-scene.html
+++ b/google-map-scene.html
@@ -23,6 +23,9 @@ Fired when the scene's location has been changed.
 <polymer-element name="google-map-scene" attributes="address zoom">
 <template>
   <style>
+    :host {
+      display: none;
+    }
   </style>
 
 </template>


### PR DESCRIPTION
Sets scene display to none.

This ensures that the content is not flashed into view on initialisation.

All content shown is controlled by the storyboard.
