### PR TITLE
Add small check before geocoding

### DIFF
--- a/google-map-storyboard.html
+++ b/google-map-storyboard.html
@@ -288,7 +288,7 @@ Fired when the storybord's google map is ready to be rendered.
     },
 
     geocodeScene: function(scene) {
-      if (scene.ignoreAddress) return;
+      if (scene.ignoreAddress || !scene.address) return;
       var address = scene.address.valueOf();
       this.geocoder = this.geocoder || new google.maps.Geocoder();
       this.geocoder.geocode({address: address}, 


### PR DESCRIPTION
Sometimes the 'updateScene' function is called before the address
being set has flowed through to the polymer element if setting it
using dev tools.

This fixes the bug by making sure that the address is already loaded.
