### PR TITLE
relative imports

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -15,7 +15,7 @@ permissions and limitations under the License.
 <html>
 <head>
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-  <script src="bower_components/webcomponentsjs/webcomponents.min.js"></script>
+  <script src="../webcomponentsjs/webcomponents.min.js"></script>
   <link rel="import" href="google-map-storyboard.html">
   <link rel="import" href="google-map-scene.html">
 </head>

--- a/google-map-scene.html
+++ b/google-map-scene.html
@@ -48,8 +48,8 @@ Fired when the scene's location or address has been changed.
 
 @event scene-changed
 -->
-<link rel="import" href="bower_components/polymer/polymer.html">
-<link rel="import" href="bower_components/google-apis/google-apis.html">
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../google-apis/google-apis.html">
 
 <polymer-element name="google-map-scene" attributes="address zoom">
 <template>

--- a/google-map-storyboard.html
+++ b/google-map-storyboard.html
@@ -38,10 +38,10 @@ Fired when the storybord's google map is ready to be rendered.
 
 @event google-map-storyboard-ready
 -->
-<link rel="import" href="bower_components/polymer/polymer.html">
-<link rel="import" href="bower_components/google-apis/google-apis.html">
-<link rel="import" href="bower_components/core-icons/av-icons.html">
-<link rel="import" href="bower_components/core-icon-button/core-icon-button.html">
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../google-apis/google-apis.html">
+<link rel="import" href="../core-icons/av-icons.html">
+<link rel="import" href="../core-icon-button/core-icon-button.html">
 <link rel="import" href="google-map-scene.html">
 <script src="TransitionManager.js"></script>
 


### PR DESCRIPTION
Odd, but probably the right way to have our imports. Development needs to happen inside a `bower_components` folder.